### PR TITLE
cd 명령어 실행 함수 생성

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@
 #    By: sunpark <sunpark@student.42seoul.kr>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/11/22 22:02:20 by sunpark           #+#    #+#              #
-#    Updated: 2021/01/11 15:54:38 by hyukim           ###   ########.fr        #
+#    Updated: 2021/01/11 17:20:59 by hyukim           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 SRC		= main.c free_utils.c tokenize/cmd_io.c tokenize/cmd_split.c \
 		  tokenize/sp2cmd.c tokenize/exec_cmd.c tokenize/ft_strequ.c \
 		  tokenize/ft_sp_size.c \
-		  command/ft_pwd.c
+		  command/ft_pwd.c command/ft_cd.c
 
 SRCDIR	= ./srcs/
 SRCS	= $(addprefix $(SRCDIR), $(SRC))

--- a/srcs/command/ft_cd.c
+++ b/srcs/command/ft_cd.c
@@ -1,24 +1,21 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   minishell_command.h                                :+:      :+:    :+:   */
+/*   ft_cd.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: hyukim <hyukim@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2021/01/11 15:52:01 by hyukim            #+#    #+#             */
-/*   Updated: 2021/01/11 17:21:54 by hyukim           ###   ########.fr       */
+/*   Created: 2021/01/11 17:12:37 by hyukim            #+#    #+#             */
+/*   Updated: 2021/01/11 17:22:33 by hyukim           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef MINISHELL_COMMAND_H
-# define MINISHELL_COMMAND_H
+#include "minishell.h"
 
-# include <unistd.h>
-# include <string.h>
-# include "minishell_token.h"
-
-# define MAX_PATH_LEN 4096
-
-void		ft_pwd(void);
-void		ft_cd(t_cmd cmd);
-#endif
+void	ft_cd(t_cmd cmd)
+{
+	if (cmd.name == NULL || cmd.arg == NULL || ft_sp_size(cmd.arg) == 0)
+		return ;
+	if (chdir(cmd.arg[0]) == -1)
+		ft_printf("bash: cd: %s: %s\n", cmd.arg[0], strerror(errno));
+}

--- a/srcs/tokenize/exec_cmd.c
+++ b/srcs/tokenize/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: hyukim <hyukim@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/08 16:55:16 by hyukim            #+#    #+#             */
-/*   Updated: 2021/01/11 16:04:08 by hyukim           ###   ########.fr       */
+/*   Updated: 2021/01/11 17:20:47 by hyukim           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ void		exec_cmd(t_cmd cmd)
 	if (ft_strequ(cmd.name, "echo"))
 		ft_printf("ECHO\n");
 	else if (ft_strequ(cmd.name, "cd"))
-		ft_printf("CD\n");
+		ft_cd(cmd);
 	else if (ft_strequ(cmd.name, "pwd"))
 		ft_pwd();
 	else if (ft_strequ(cmd.name, "export"))


### PR DESCRIPTION
## 구현 내용
`unistd.h`에 있는 `chdir()`함수를 사용하여 `cd` 명령어와 같은 동작을 하는 `ft_cd` 함수 생성
- `int chdir(const char *path);` `path`에 이동할 상대/절대 경로값을 넣고 실행했을 때, 이상이 없다면 현재 working directory를 이동
- 실행시 에러가 발생한다면, `strerror`를 통해 `errno`에 맞는 에러 메시지 출력
- **`t_bash`에 따로 현재 위치를 저장하는 변수를 만들지 않음** -> `ft_pwd`를 통해서 필요할 때 호출하면 된다고 생각했습니다.
- make, leaks, norm 체크
## 추가해야할 부분
- 환경변수 처리 부분이 완료되면 `~`, ` ` 등의 입력을 처리하는 부분 구현 필요

close #10 